### PR TITLE
Fix infinite path length issue in path_filter

### DIFF
--- a/tests/mobility1/run.py
+++ b/tests/mobility1/run.py
@@ -63,7 +63,7 @@ def run(protocol, csvfile, step_duration, step_distance):
 		# Wait until wait seconds are over, else error
 		tools.wait(wait_beg_ms, step_duration)
 
-		paths = tools.get_random_paths(state, 2 * 200)
+		paths = tools.get_random_paths(state, 2 * 400)
 		paths = tools.filter_paths(state, paths, min_hops=2, path_count=200)
 		ping_result = tools.ping_paths(paths=paths, duration_ms=2000, verbosity='verbose', remotes=remotes)
 

--- a/tools.py
+++ b/tools.py
@@ -180,12 +180,12 @@ def filter_paths(network, paths, min_hops=None, max_hops=None, path_count=None):
     filtered = []
     for path in paths:
         d = dijkstra.find_shortest_distance(path[0], path[1])
-        if d >= min_hops and d <= max_hops:
+        if d >= min_hops and d <= max_hops and d != math.inf:
             filtered.append(path)
 
     if path_count is not None:
         if len(filtered) < path_count:
-            eprint('Only {len(filtered)} paths left after filtering. Required were at least {path_count}.')
+            eprint('Only {} paths left after filtering. Required were at least {}.'.format(len(filtered), path_count))
             exit(1)
 
         if len(filtered) > path_count:


### PR DESCRIPTION
If no `max_hops` was supplied, `path_filter` uses `math.inf` as the max hops. It seems that, when no path between two nodes exists, `math.inf` is also used as the path length. This was causing `path_filter` to keep nonexistant paths if no finite `max_hops` was set, as described in #10. This PR updates `path_filter` to check for the special case of infinite path length, and updates mobility1 to supply enough paths for the filter to succeed. It also fixes a minor logging issue that I was seeing when too few paths were supplied.

EDIT: I imagine that mobility2 may also need updating, if it's supplying too few paths to the filter. Unfortunately, that test doesn't seem to want to run on my laptop (10s wait time to update is apparently too small), and I haven't had a chance to try running it with a slower wait time to see if it works.