### PR TITLE
Fix bugs in mobility2

### DIFF
--- a/tests/mobility2/plot.sh
+++ b/tests/mobility2/plot.sh
@@ -3,7 +3,7 @@
 # to distinguish multiple runs (if needed)
 prefix="$1"
 
-title='Mobility1 Test for 50 randomly placed nodes in a 1x1km square.\nMove in random directions of 50-400m in 50m increments.\nWait and measure ping arrival over 60s in 10s intervals each time.\n100MBit/s - 1ms latency links.'
+title='Mobility2 Test for 50 randomly placed nodes in a 1x1km square.\nMove in random directions of 50-400m in 50m increments.\nWait and measure ping arrival over 60s in 10s intervals each time.\n100MBit/s - 1ms latency links.'
 
 # progress of packet arrival rate
 gnuplot -e "

--- a/tests/mobility2/run.py
+++ b/tests/mobility2/run.py
@@ -15,6 +15,7 @@ import mobility
 from shared import Remote
 import shared
 import ping
+import traffic
 
 remotes= [Remote()]
 


### PR DESCRIPTION
The "traffic" import was missing, which resulted in a NameError, and the graph was incorrectly titled "Mobility1".